### PR TITLE
specify a separate `get_clustering_root_data_dir()` - handle cases where raw ephys and clustering results are stored at different root locations (e.g. different mount points)

### DIFF
--- a/element_array_ephys/__init__.py
+++ b/element_array_ephys/__init__.py
@@ -1,5 +1,3 @@
-__author__ = "DataJoint NEURO"
-__date__ = "December 15, 2020"
-__version__ = "0.0.1"
+import datajoint as dj
 
-__all__ = ['__author__', '__version__', '__date__']
+dj.config['enable_python_native_blobs'] = True

--- a/element_array_ephys/ephys.py
+++ b/element_array_ephys/ephys.py
@@ -63,8 +63,14 @@ def activate(ephys_schema_name, probe_schema_name=None, *, create_schema=True,
 
 def get_ephys_root_data_dir() -> str:
     """
+    All data paths, directories in DataJoint Elements are recommended to be stored as
+    relative paths, with respect to some user-configured "root" directory,
+     this can change machine to machine (e.g. changing mounted drive locations)
+
     get_ephys_root_data_dir() -> str
-        Retrieve the root data directory - e.g. containing all subject/sessions ephys data
+        This user-provided function retrieves the root data directory
+         containing all subject/sessions ephys data
+         (e.g. acquired SpikeGLX or Open Ephys files)
         :return: a string for full path to the ephys root data directory
     """
     return _linking_module.get_ephys_root_data_dir()
@@ -72,8 +78,14 @@ def get_ephys_root_data_dir() -> str:
 
 def get_clustering_root_data_dir() -> str:
     """
+    All data paths, directories in DataJoint Elements are recommended to be stored as
+    relative paths, with respect to some user-configured "root" directory,
+     this can change machine to machine (e.g. changing mounted drive locations)
+
     get_clustering_root_data_dir() -> str
-        Retrieve the root data directory containing all subject/sessions clustering data
+        This user-provided function retrieves the root data directory
+         containing all subject/sessions clustering data
+        (e.g. output files from spike sorting routines)
         Note: if not provided, use "get_ephys_root_data_dir()"
         :return: a string for full path to the clustering root data directory
     """
@@ -393,7 +405,7 @@ class ClusteringTask(dj.Manual):
     -> EphysRecording
     -> ClusteringParamSet
     ---
-    clustering_output_dir: varchar(255)  #  clustering output directory relative to root data directory
+    clustering_output_dir: varchar(255)  #  clustering output directory relative to the clustering root data directory
     task_mode='load': enum('load', 'trigger')  # 'load': load computed analysis results, 'trigger': trigger computation
     """
 
@@ -437,7 +449,7 @@ class Curation(dj.Manual):
     curation_id: int
     ---
     curation_time: datetime             # time of generation of this set of curated clustering results 
-    curation_output_dir: varchar(255)   # output directory of the curated results, relative to root data directory
+    curation_output_dir: varchar(255)   # output directory of the curated results, relative to clustering root data directory
     quality_control: bool               # has this clustering result undergone quality control?
     manual_curation: bool               # has manual curation been performed on this clustering result?
     curation_note='': varchar(2000)  

--- a/element_array_ephys/ephys.py
+++ b/element_array_ephys/ephys.py
@@ -111,10 +111,10 @@ def get_session_directory(session_key: dict) -> str:
 
 @schema
 class AcquisitionSoftware(dj.Lookup):
-    definition = """  # Name of software used for recording of neuropixels probes - SpikeGLX or OpenEphys
+    definition = """  # Name of software used for recording of neuropixels probes - SpikeGLX or Open Ephys
     acq_software: varchar(24)    
     """
-    contents = zip(['SpikeGLX', 'OpenEphys'])
+    contents = zip(['SpikeGLX', 'Open Ephys'])
 
 
 @schema
@@ -169,7 +169,7 @@ class EphysRecording(dj.Imported):
         # search session dir and determine acquisition software
         acq_software = None
         for ephys_pattern, ephys_acq_type in zip(['*.ap.meta', '*.oebin'],
-                                                 ['SpikeGLX', 'OpenEphys']):
+                                                 ['SpikeGLX', 'Open Ephys']):
             ephys_meta_filepaths = [fp for fp in sess_dir.rglob(ephys_pattern)]
             if len(ephys_meta_filepaths):
                 acq_software = ephys_acq_type
@@ -177,7 +177,7 @@ class EphysRecording(dj.Imported):
 
         if acq_software is None:
             raise FileNotFoundError(f'Ephys recording data not found!'
-                                    f' Neither SpikeGLX nor OpenEphys recording files found')
+                                    f' Neither SpikeGLX nor Open Ephys recording files found')
 
         if acq_software == 'SpikeGLX':
             for meta_filepath in ephys_meta_filepaths:
@@ -209,7 +209,7 @@ class EphysRecording(dj.Imported):
                     **insertion_key,
                     'file_path': meta_filepath.relative_to(root_dir).as_posix()})
 
-        elif acq_software == 'OpenEphys':
+        elif acq_software == 'Open Ephys':
             loaded_oe = openephys.OpenEphys(sess_dir)
             for probe_SN, oe_probe in loaded_oe.probes.items():
                 insertion_key = (ProbeInsertion & key & {'probe': probe_SN}).fetch1('KEY')
@@ -298,7 +298,7 @@ class LFP(dj.Imported):
                                       'shank_col': shank_col,
                                       'shank_row': shank_row}).fetch1('KEY'))
 
-        elif acq_software == 'OpenEphys':
+        elif acq_software == 'Open Ephys':
             sess_dir = pathlib.Path(get_session_directory(key))
             loaded_oe = openephys.OpenEphys(sess_dir)
             oe_probe = loaded_oe.probes[probe_sn]
@@ -606,7 +606,7 @@ class Waveform(dj.Imported):
                 npx_meta_fp = ephys_root_dir / (EphysRecording.EphysFile & key
                                                 & 'file_path LIKE "%.ap.meta"').fetch1('file_path')
                 npx_recording = spikeglx.SpikeGLX(npx_meta_fp.parent)
-            elif acq_software == 'OpenEphys':
+            elif acq_software == 'Open Ephys':
                 sess_dir = pathlib.Path(get_session_directory(key))
                 loaded_oe = openephys.OpenEphys(sess_dir)
                 npx_recording = loaded_oe.probes[probe_sn]
@@ -697,7 +697,7 @@ def get_neuropixels_channel2electrode_map(ephys_recording_key, acq_software):
                                                     & {'shank': shank,
                                                        'shank_col': shank_col,
                                                        'shank_row': shank_row}).fetch1('KEY')
-    elif acq_software == 'OpenEphys':
+    elif acq_software == 'Open Ephys':
         sess_dir = pathlib.Path(get_session_directory(ephys_recording_key))
         loaded_oe = openephys.OpenEphys(sess_dir)
         probe_sn = (ProbeInsertion & ephys_recording_key).fetch1('probe')

--- a/element_array_ephys/ephys.py
+++ b/element_array_ephys/ephys.py
@@ -556,7 +556,7 @@ class Waveform(dj.Imported):
 
     class UnitElectrode(dj.Part):
         definition = """
-        -> master.UnitWaveform
+        -> master.Unit
         -> probe.ElectrodeConfig.Electrode  
         --- 
         waveform_mean: longblob   # (uV) mean over all spikes

--- a/element_array_ephys/ephys.py
+++ b/element_array_ephys/ephys.py
@@ -639,39 +639,6 @@ class Waveform(dj.Imported):
             self.UnitElectrode.insert(unit_electrode_waveforms, ignore_extra_fields=True)
 
 
-# ----------- Quality Control ----------
-
-
-@schema
-class QualityControl(dj.Imported):
-    definition = """  # Quality control metrics for a set of CuratedClustering
-    -> CuratedClustering
-    """
-
-    class ClusterQualityMetrics(dj.Part):
-        definition = """  # Quality metrics for each cluster
-        -> master
-        -> CuratedClustering.Unit
-        ---
-        amp: float
-        snr: float
-        isi_violation: float
-        firing_rate: float
-        presence_ratio: float  # Fraction of epoch in which spikes are present
-        amplitude_cutoff: float  # Estimate of miss rate based on amplitude histogram
-        isolation_distance=null: float  # Distance to nearest cluster in Mahalanobis space
-        l_ratio=null: float  # 
-        d_prime=null: float  # Classification accuracy based on LDA
-        nn_hit_rate=null: float  # 
-        nn_miss_rate=null: float
-        silhouette_score=null: float  # Standard metric for cluster overlap
-        max_drift=null: float  # Maximum change in spike depth throughout recording
-        cumulative_drift=null: float  # Cumulative change in spike depth throughout recording 
-        """
-
-    def make(self, key):
-        pass
-
 # ---------------- HELPER FUNCTIONS ----------------
 
 

--- a/element_array_ephys/ephys.py
+++ b/element_array_ephys/ephys.py
@@ -641,31 +641,33 @@ class Waveform(dj.Imported):
 
 # ----------- Quality Control ----------
 
-@schema
-class ClusterQualityMetrics(dj.Imported):
-    definition = """
-    -> CuratedClustering.Unit
-    ---
-    amp: float
-    snr: float
-    isi_violation: float
-    firing_rate: float
 
-    presence_ratio: float  # Fraction of epoch in which spikes are present
-    amplitude_cutoff: float  # Estimate of miss rate based on amplitude histogram
-    isolation_distance=null: float  # Distance to nearest cluster in Mahalanobis space
-    l_ratio=null: float  # 
-    d_prime=null: float  # Classification accuracy based on LDA
-    nn_hit_rate=null: float  # 
-    nn_miss_rate=null: float
-    silhouette_score=null: float  # Standard metric for cluster overlap
-    max_drift=null: float  # Maximum change in spike depth throughout recording
-    cumulative_drift=null: float  # Cumulative change in spike depth throughout recording 
+@schema
+class QualityControl(dj.Imported):
+    definition = """  Quality control metrics for a set of CuratedClustering
+    -> CuratedClustering
     """
 
-    @property
-    def key_source(self):
-        return Clustering
+    class ClusterQualityMetrics(dj.Part):
+        definition = """  # Quality metrics for each cluster
+        -> master
+        -> CuratedClustering.Unit
+        ---
+        amp: float
+        snr: float
+        isi_violation: float
+        firing_rate: float
+        presence_ratio: float  # Fraction of epoch in which spikes are present
+        amplitude_cutoff: float  # Estimate of miss rate based on amplitude histogram
+        isolation_distance=null: float  # Distance to nearest cluster in Mahalanobis space
+        l_ratio=null: float  # 
+        d_prime=null: float  # Classification accuracy based on LDA
+        nn_hit_rate=null: float  # 
+        nn_miss_rate=null: float
+        silhouette_score=null: float  # Standard metric for cluster overlap
+        max_drift=null: float  # Maximum change in spike depth throughout recording
+        cumulative_drift=null: float  # Cumulative change in spike depth throughout recording 
+        """
 
     def make(self, key):
         pass

--- a/element_array_ephys/ephys.py
+++ b/element_array_ephys/ephys.py
@@ -644,7 +644,7 @@ class Waveform(dj.Imported):
 
 @schema
 class QualityControl(dj.Imported):
-    definition = """  Quality control metrics for a set of CuratedClustering
+    definition = """  # Quality control metrics for a set of CuratedClustering
     -> CuratedClustering
     """
 

--- a/element_array_ephys/probe.py
+++ b/element_array_ephys/probe.py
@@ -17,6 +17,11 @@ def activate(schema_name, create_schema=True, create_tables=True):
     """
     schema.activate(schema_name, create_schema=create_schema, create_tables=create_tables)
 
+    # Add neuropixels probes
+    for probe_type in ('neuropixels 1.0 - 3A', 'neuropixels 1.0 - 3B',
+                       'neuropixels 2.0 - SS', 'neuropixels 2.0 - MS'):
+        ProbeType.create_neuropixels_probe(probe_type)
+
 
 @schema
 class ProbeType(dj.Lookup):

--- a/element_array_ephys/readers/openephys.py
+++ b/element_array_ephys/readers/openephys.py
@@ -93,13 +93,15 @@ class OpenEphys:
                         assert continuous_info['sample_rate'] == analog_signal.sample_rate == 2500
                         continuous_type = 'lfp'
 
-                    if getattr(probe, continuous_type + '_meta') is None:
-                        continuous_info['channels_ids'] = analog_signal.channel_ids
-                        continuous_info['channels_names'] = analog_signal.channel_names
-                        continuous_info['channels_gains'] = analog_signal.gains
-                        setattr(probe, continuous_type + '_meta', continuous_info)
+                    meta = getattr(probe, continuous_type + '_meta')
+                    if not meta:
+                        meta.update(**continuous_info,
+                                    channels_ids=analog_signal.channel_ids,
+                                    channels_names=analog_signal.channel_names,
+                                    channels_gains=analog_signal.gains)
 
-                    probe.__dict__[f'{continuous_type}_analog_signals'].append(analog_signal)
+                    signal = getattr(probe, continuous_type + '_analog_signals')
+                    signal.append(analog_signal)
 
         return probes
 
@@ -120,8 +122,8 @@ class Probe:
             self.probe_SN = self.probe_info['@probe_serial_number']
             self.probe_model = self.probe_info['@probe_name']
 
-        self.ap_meta = None
-        self.lfp_meta = None
+        self.ap_meta = {}
+        self.lfp_meta = {}
 
         self.ap_analog_signals = []
         self.lfp_analog_signals = []

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,0 +1,2 @@
+"""Package metadata."""
+__version__ = '0.1.1'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup, find_packages
 from os import path
 
+pkg_name = 'element_array_ephys'
 here = path.abspath(path.dirname(__file__))
 
 long_description = """"
@@ -10,9 +11,12 @@ DataJoint Element for Extracellular Array Electrophysiology with Neuropixels pro
 with open(path.join(here, 'requirements.txt')) as f:
     requirements = f.read().splitlines()
 
+with open(path.join(here, pkg_name, 'version.py')) as f:
+    exec(f.read())
+
 setup(
     name='element-array-ephys',
-    version='0.0.1',
+    version=__version__,
     description="DataJoint Element for Extracellular Array Electrophysiology",
     long_description=long_description,
     author='DataJoint NEURO',


### PR DESCRIPTION
PR includes:

+ specify a separate `get_clustering_root_data_dir()` - handle cases where raw ephys and clustering results are stored at different root locations (e.g. different mount points)
+ smaller batch ingest for Waveform and LFP - help with memory issue
+ Redesign Waveform and QualityControl as master table - fix #14 