### PR TITLE
Fix for case where `pc_features.npy` does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
  [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.1.2] - 2022-06-09
+
++ Bugfix - Handle case where `pc_features.npy` does not exist.
+
 ## [0.1.1] - 2022-06-01
 
 + Add - Secondary attributes to `PreClusterParamSteps` table

--- a/element_array_ephys/ephys_acute.py
+++ b/element_array_ephys/ephys_acute.py
@@ -533,7 +533,8 @@ class CuratedClustering(dj.Imported):
         # -- Spike-sites and Spike-depths --
         spike_sites = np.array([channel2electrodes[s]['electrode']
                                 for s in kilosort_dataset.data['spike_sites']])
-        spike_depths = kilosort_dataset.data['spike_depths']
+        spike_depths = kilosort_dataset.data['spike_depths'] \
+                        if 'pc_features' in kilosort_dataset.data else None
 
         # -- Insert unit, label, peak-chn
         units = []
@@ -551,7 +552,7 @@ class CuratedClustering(dj.Imported):
                     'spike_times': unit_spike_times,
                     'spike_count': spike_count,
                     'spike_sites': spike_sites[kilosort_dataset.data['spike_clusters'] == unit],
-                    'spike_depths': spike_depths[kilosort_dataset.data['spike_clusters'] == unit]})
+                    'spike_depths': spike_depths[kilosort_dataset.data['spike_clusters'] == unit] if spike_depths else None})
 
         self.insert1(key)
         self.Unit.insert([{**key, **u} for u in units])

--- a/element_array_ephys/ephys_acute.py
+++ b/element_array_ephys/ephys_acute.py
@@ -503,7 +503,7 @@ class CuratedClustering(dj.Imported):
         spike_count: int         # how many spikes in this recording for this unit
         spike_times: longblob    # (s) spike times of this unit, relative to the start of the EphysRecording
         spike_sites : longblob   # array of electrode associated with each spike
-        spike_depths : longblob  # (um) array of depths associated with each spike, relative to the (0, 0) of the probe    
+        spike_depths=null : longblob  # (um) array of depths associated with each spike, relative to the (0, 0) of the probe    
         """
 
     def make(self, key):

--- a/element_array_ephys/ephys_acute.py
+++ b/element_array_ephys/ephys_acute.py
@@ -533,8 +533,7 @@ class CuratedClustering(dj.Imported):
         # -- Spike-sites and Spike-depths --
         spike_sites = np.array([channel2electrodes[s]['electrode']
                                 for s in kilosort_dataset.data['spike_sites']])
-        spike_depths = kilosort_dataset.data['spike_depths'] \
-                        if 'pc_features' in kilosort_dataset.data else None
+        spike_depths = kilosort_dataset.data['spike_depths']
 
         # -- Insert unit, label, peak-chn
         units = []

--- a/element_array_ephys/ephys_chronic.py
+++ b/element_array_ephys/ephys_chronic.py
@@ -532,7 +532,8 @@ class CuratedClustering(dj.Imported):
         # -- Spike-sites and Spike-depths --
         spike_sites = np.array([channel2electrodes[s]['electrode']
                                 for s in kilosort_dataset.data['spike_sites']])
-        spike_depths = kilosort_dataset.data['spike_depths']
+        spike_depths = kilosort_dataset.data['spike_depths'] \
+                        if 'pc_features' in kilosort_dataset.data else None
 
         # -- Insert unit, label, peak-chn
         units = []
@@ -550,7 +551,7 @@ class CuratedClustering(dj.Imported):
                     'spike_times': unit_spike_times,
                     'spike_count': spike_count,
                     'spike_sites': spike_sites[kilosort_dataset.data['spike_clusters'] == unit],
-                    'spike_depths': spike_depths[kilosort_dataset.data['spike_clusters'] == unit]})
+                    'spike_depths': spike_depths[kilosort_dataset.data['spike_clusters'] == unit] if spike_depths else None})
 
         self.insert1(key)
         self.Unit.insert([{**key, **u} for u in units])

--- a/element_array_ephys/ephys_chronic.py
+++ b/element_array_ephys/ephys_chronic.py
@@ -502,7 +502,7 @@ class CuratedClustering(dj.Imported):
         spike_count: int         # how many spikes in this recording for this unit
         spike_times: longblob    # (s) spike times of this unit, relative to the start of the EphysRecording
         spike_sites : longblob   # array of electrode associated with each spike
-        spike_depths : longblob  # (um) array of depths associated with each spike, relative to the (0, 0) of the probe    
+        spike_depths=null : longblob  # (um) array of depths associated with each spike, relative to the (0, 0) of the probe    
         """
 
     def make(self, key):

--- a/element_array_ephys/ephys_chronic.py
+++ b/element_array_ephys/ephys_chronic.py
@@ -532,8 +532,7 @@ class CuratedClustering(dj.Imported):
         # -- Spike-sites and Spike-depths --
         spike_sites = np.array([channel2electrodes[s]['electrode']
                                 for s in kilosort_dataset.data['spike_sites']])
-        spike_depths = kilosort_dataset.data['spike_depths'] \
-                        if 'pc_features' in kilosort_dataset.data else None
+        spike_depths = kilosort_dataset.data['spike_depths']
 
         # -- Insert unit, label, peak-chn
         units = []

--- a/element_array_ephys/ephys_precluster.py
+++ b/element_array_ephys/ephys_precluster.py
@@ -636,7 +636,7 @@ class CuratedClustering(dj.Imported):
         spike_count: int         # how many spikes in this recording for this unit
         spike_times: longblob    # (s) spike times of this unit, relative to the start of the EphysRecording
         spike_sites : longblob   # array of electrode associated with each spike
-        spike_depths : longblob  # (um) array of depths associated with each spike, relative to the (0, 0) of the probe    
+        spike_depths=null : longblob  # (um) array of depths associated with each spike, relative to the (0, 0) of the probe    
         """
 
     def make(self, key):

--- a/element_array_ephys/ephys_precluster.py
+++ b/element_array_ephys/ephys_precluster.py
@@ -667,7 +667,8 @@ class CuratedClustering(dj.Imported):
         # -- Spike-sites and Spike-depths --
         spike_sites = np.array([channel2electrodes[s]['electrode']
                                 for s in kilosort_dataset.data['spike_sites']])
-        spike_depths = kilosort_dataset.data['spike_depths']
+        spike_depths = kilosort_dataset.data['spike_depths'] \
+                        if 'pc_features' in kilosort_dataset.data else None
 
         # -- Insert unit, label, peak-chn
         units = []
@@ -685,7 +686,7 @@ class CuratedClustering(dj.Imported):
                     'spike_times': unit_spike_times,
                     'spike_count': spike_count,
                     'spike_sites': spike_sites[kilosort_dataset.data['spike_clusters'] == unit],
-                    'spike_depths': spike_depths[kilosort_dataset.data['spike_clusters'] == unit]})
+                    'spike_depths': spike_depths[kilosort_dataset.data['spike_clusters'] == unit] if spike_depths else None})
 
         self.insert1(key)
         self.Unit.insert([{**key, **u} for u in units])

--- a/element_array_ephys/ephys_precluster.py
+++ b/element_array_ephys/ephys_precluster.py
@@ -667,8 +667,7 @@ class CuratedClustering(dj.Imported):
         # -- Spike-sites and Spike-depths --
         spike_sites = np.array([channel2electrodes[s]['electrode']
                                 for s in kilosort_dataset.data['spike_sites']])
-        spike_depths = kilosort_dataset.data['spike_depths'] \
-                        if 'pc_features' in kilosort_dataset.data else None
+        spike_depths = kilosort_dataset.data['spike_depths']
 
         # -- Insert unit, label, peak-chn
         units = []

--- a/element_array_ephys/readers/kilosort.py
+++ b/element_array_ephys/readers/kilosort.py
@@ -127,19 +127,20 @@ class Kilosort:
 
     def extract_spike_depths(self):
         """ Reimplemented from https://github.com/cortex-lab/spikes/blob/master/analysis/ksDriftmap.m """
-        ycoords = self.data['channel_positions'][:, 1]
-        pc_features = self.data['pc_features'][:, 0, :]  # 1st PC only
-        pc_features = np.where(pc_features < 0, 0, pc_features)
+        if 'pc_features' in self.data:
+            ycoords = self.data['channel_positions'][:, 1]
+            pc_features = self.data['pc_features'][:, 0, :]  # 1st PC only
+            pc_features = np.where(pc_features < 0, 0, pc_features)
 
-        # ---- compute center of mass of these features (spike depths) ----
+            # ---- compute center of mass of these features (spike depths) ----
 
-        # which channels for each spike?
-        spk_feature_ind = self.data['pc_feature_ind'][self.data['spike_templates'], :]
-        # ycoords of those channels?
-        spk_feature_ycoord = ycoords[spk_feature_ind]
-        # center of mass is sum(coords.*features)/sum(features)
-        self._data['spike_depths'] = (np.sum(spk_feature_ycoord * pc_features**2, axis=1)
-                                      / np.sum(pc_features**2, axis=1))
+            # which channels for each spike?
+            spk_feature_ind = self.data['pc_feature_ind'][self.data['spike_templates'], :]
+            # ycoords of those channels?
+            spk_feature_ycoord = ycoords[spk_feature_ind]
+            # center of mass is sum(coords.*features)/sum(features)
+            self._data['spike_depths'] = (np.sum(spk_feature_ycoord * pc_features**2, axis=1)
+                                        / np.sum(pc_features**2, axis=1))
 
         # ---- extract spike sites ----
         max_site_ind = np.argmax(np.abs(self.data['templates']).max(axis=1), axis=1)

--- a/element_array_ephys/readers/kilosort.py
+++ b/element_array_ephys/readers/kilosort.py
@@ -143,7 +143,8 @@ class Kilosort:
             # center of mass is sum(coords.*features)/sum(features)
             self._data['spike_depths'] = (np.sum(spk_feature_ycoord * pc_features**2, axis=1)
                                         / np.sum(pc_features**2, axis=1))
-
+else:
+    self._data['spike_depths'] = None
         # ---- extract spike sites ----
         max_site_ind = np.argmax(np.abs(self.data['templates']).max(axis=1), axis=1)
         spike_site_ind = max_site_ind[self.data['spike_templates']]

--- a/element_array_ephys/readers/kilosort.py
+++ b/element_array_ephys/readers/kilosort.py
@@ -129,6 +129,7 @@ class Kilosort:
 
     def extract_spike_depths(self):
         """ Reimplemented from https://github.com/cortex-lab/spikes/blob/master/analysis/ksDriftmap.m """
+        
         if 'pc_features' in self.data:
             ycoords = self.data['channel_positions'][:, 1]
             pc_features = self.data['pc_features'][:, 0, :]  # 1st PC only
@@ -143,8 +144,9 @@ class Kilosort:
             # center of mass is sum(coords.*features)/sum(features)
             self._data['spike_depths'] = (np.sum(spk_feature_ycoord * pc_features**2, axis=1)
                                         / np.sum(pc_features**2, axis=1))
-else:
-    self._data['spike_depths'] = None
+        else:
+            self._data['spike_depths'] = None
+
         # ---- extract spike sites ----
         max_site_ind = np.argmax(np.abs(self.data['templates']).max(axis=1), axis=1)
         spike_site_ind = max_site_ind[self.data['spike_templates']]

--- a/element_array_ephys/readers/kilosort.py
+++ b/element_array_ephys/readers/kilosort.py
@@ -91,6 +91,8 @@ class Kilosort:
                 self._data[base] = (np.reshape(d, d.shape[0])
                                     if d.ndim == 2 and d.shape[1] == 1 else d)
 
+        self._data['channel_map'] = self._data['channel_map'].flatten()
+
         # Read the Cluster Groups
         for cluster_pattern, cluster_col_name in zip(['cluster_groups.*', 'cluster_KSLabel.*'],
                                                      ['group', 'KSLabel']):

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = '0.1.1'
+__version__ = '0.1.2'


### PR DESCRIPTION
- When Kilosort does not output a `pc_features.npy` file, set `CuratedClustering.Unit::spike_depths` attribute to null.
- Will create new tag, release, and PyPI publication once this is merged.