### PR TITLE
Add QC dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ docker-compose.y*ml
 # vscode settings
 .vscode
 *.code-workspace
+
+# exports/notes
+temp*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Update - clustering step, update duration for "median_subtraction" step
 + Bugfix - handles single probe recording in "Neuropix-PXI" format
 + Update - safeguard in creating/inserting probe types upon probe activation
++ Add - quality control metric dashboard
 
 ## [0.2.0] - 2022-10-28
 

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -34,6 +34,7 @@ def activate(
         ephys_schema_name (str): A string containing the name of the ephys schema.
         probe_schema_name (str): A string containing the name of the probe scehma.
         create_schema (bool): If True, schema will be created in the database.
+        create_tables (bool): If True, tables related to the schema will be created in the database.
         linking_module (str): A string containing the module name or module containing the required dependencies to activate the schema.
 
     Dependencies:

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -34,7 +34,6 @@ def activate(
         ephys_schema_name (str): A string containing the name of the ephys schema.
         probe_schema_name (str): A string containing the name of the probe scehma.
         create_schema (bool): If True, schema will be created in the database.
-        create_tables (bool): If True, tables related to the schema will be created in the database.
         linking_module (str): A string containing the module name or module containing the required dependencies to activate the schema.
 
     Dependencies:

--- a/element_array_ephys/ephys_report.py
+++ b/element_array_ephys/ephys_report.py
@@ -1,9 +1,10 @@
-import pathlib
 import datetime
-import datajoint as dj
+import pathlib
 import typing as T
+from uuid import UUID
 
-from element_interface.utils import insert1_skip_full_duplicates
+import datajoint as dj
+from element_interface.utils import dict_to_uuid
 
 schema = dj.schema()
 
@@ -102,9 +103,9 @@ class UnitLevelReport(dj.Computed):
     def make(self, key):
 
         from .plotting.unit_level import (
-            plot_waveform,
             plot_auto_correlogram,
             plot_depth_waveforms,
+            plot_waveform,
         )
 
         sampling_rate = (ephys.EphysRecording & key).fetch1(
@@ -145,9 +146,14 @@ class QualityMetricCutoffs(dj.Lookup):
     amplitude_cutoff_maximum=null : float # Defualt null, no cutoff applied
     presence_ratio_minimum=null   : float # Defualt null, no cutoff applied
     isi_violations_maximum=null   : float # Defualt null, no cutoff applied
+    cutoffs_hash: uuid
+    unique index (cutoffs_hash)
     """
 
-    contents = [(0, None, None, None), (1, 0.1, 0.9, 0.5)]
+    contents = [
+        (0, None, None, None, UUID("5d835de1-e1af-1871-d81f-d12a9702ff5f")),
+        (1, 0.1, 0.9, 0.5, UUID("f74ccd77-0b3a-2bf8-0bfd-ec9713b5dca8")),
+    ]
 
     @classmethod
     def insert_new_cutoffs(
@@ -157,18 +163,38 @@ class QualityMetricCutoffs(dj.Lookup):
         presence_ratio_minimum: float = None,
         isi_violations_maximum: float = None,
     ):
-        if not cutoffs_id:
+        if cutoffs_id is None:
             cutoffs_id = (dj.U().aggr(cls, n="max(cutoffs_id)").fetch1("n") or 0) + 1
 
-        insert1_skip_full_duplicates(  # depends on element-interface/pull/43
-            cls,
-            dict(
-                cutoffs_id=cutoffs_id,
-                amplitude_cutoff_maximum=amplitude_cutoff_maximum,
-                presence_ratio_minimum=presence_ratio_minimum,
-                isi_violations_maximum=isi_violations_maximum,
-            ),
-        )
+        param_dict = {
+            "amplitude_cutoff_maximum": amplitude_cutoff_maximum,
+            "presence_ratio_minimum": presence_ratio_minimum,
+            "isi_violations_maximum": isi_violations_maximum,
+        }
+        param_hash = dict_to_uuid(param_dict)
+        param_query = cls & {"cutoffs_hash": param_hash}
+
+        if param_query:  # If the specified cutoff set already exists
+            existing_paramset_idx = param_query.fetch1("cutoffs_id")
+            if (
+                existing_paramset_idx == cutoffs_id
+            ):  # If the existing set has the same id: job done
+                return
+            # If not same name: human err, adding the same set with different name
+            else:
+                raise dj.DataJointError(
+                    f"The specified param-set already exists"
+                    f" - with paramset_idx: {existing_paramset_idx}"
+                )
+        else:
+            if {"cutoffs_id": cutoffs_id} in cls.proj():
+                raise dj.DataJointError(
+                    f"The specified cuttoffs_id {cutoffs_id} already exists,"
+                    f" please pick a different one."
+                )
+            cls.insert1(
+                {"cutoffs_id": cutoffs_id, **param_dict, "cutoffs_hash": param_hash}
+            )
 
 
 @schema

--- a/element_array_ephys/ephys_report.py
+++ b/element_array_ephys/ephys_report.py
@@ -149,6 +149,7 @@ class QualityMetricCutoffs(dj.Lookup):
 
     contents = [(0, None, None, None), (1, 0.1, 0.9, 0.5)]
 
+    @classmethod
     def insert_new_cutoffs(
         cls,
         cutoffs_id: int = None,

--- a/element_array_ephys/plotting/qc.py
+++ b/element_array_ephys/plotting/qc.py
@@ -1,0 +1,131 @@
+import numpy as np
+import pandas as pd
+import plotly.graph_objs as go
+from scipy.ndimage import gaussian_filter1d
+from .. import ephys_no_curation as ephys
+
+
+class QualityMetricFigs(object):
+    def __init__(self, key=None, **kwargs) -> None:
+        self._key = key
+        self._amplitude_cutoff_max = kwargs.get("amplitude_cutoff_maximum", None)
+        self._presence_ratio_min = kwargs.get("presence_ratio_minimum", None)
+        self._isi_violations_max = kwargs.get("isi_violations_maximum", None)
+        self._units = pd.DataFrame()
+
+    @property
+    def units(self):
+        assert self._key, "Must use key when retrieving units for QC figures"
+        if self._units.empty:
+            restrictions = ["TRUE"]
+            if self._amplitude_cutoff_max:
+                restrictions.append(f"amplitude_cutoff < {self._amplitude_cutoff_max}")
+            if self._presence_ratio_min:
+                restrictions.append(f"presence_ratio > {self._presence_ratio_min}")
+            if self._isi_violations_max:
+                restrictions.append(f"isi_violation < {self._isi_violations_max}")
+            " AND ".join(restrictions)
+            return (
+                ephys.QualityMetrics
+                * ephys.QualityMetrics.Cluster
+                * ephys.QualityMetrics.Waveform
+                & self._key
+                & restrictions
+            ).fetch(format="frame")
+        return self._units
+
+    def _plot_metric(
+        self,
+        data,
+        bins,
+        x_axis_label,
+        scale=1,
+        vline=None,
+    ):
+        fig = go.Figure()
+        fig.update_layout(
+            xaxis_title=x_axis_label,
+            template="plotly_dark",  # "simple_white",
+            width=350 * scale,
+            height=350 * scale,
+            margin=dict(l=20 * scale, r=20 * scale, t=20 * scale, b=20 * scale),
+            xaxis=dict(showgrid=False, zeroline=False, linewidth=2, ticks="outside"),
+            yaxis=dict(showgrid=False, linewidth=0, zeroline=True, visible=False),
+        )
+        if data.isnull().all():
+            return fig.add_annotation(text="No data available", showarrow=False)
+
+        histogram, histogram_bins = np.histogram(data, bins=bins, density=True)
+
+        fig.add_trace(
+            go.Scatter(
+                x=histogram_bins[:-1],
+                y=gaussian_filter1d(histogram, 1),  # TODO: remove smoothing
+                mode="lines",
+                line=dict(color="rgb(0, 160, 223)", width=2 * scale),  # DataJoint Blue
+                hovertemplate="%{x:.2f}<br>%{y:.2f}<extra></extra>",
+            )
+        )
+
+        if vline:
+            fig.add_vline(x=vline, line_width=2 * scale, line_dash="dash")
+
+        return fig
+
+    def empty_fig(self):  # TODO: Remove before submission?
+        return self._plot_metric(
+            pd.Series(["nan"]), np.linspace(0, 0, 0), "This fig left blank"
+        )
+
+    def firing_rate_plot(self):
+        return self._plot_metric(
+            np.log10(self.units["firing_rate"]),
+            np.linspace(-3, 2, 100),  # If linear, use np.linspace(0, 50, 100)
+            "log<sub>10</sub> firing rate (Hz)",
+        )
+
+    def presence_ratio_plot(self):
+        return self._plot_metric(
+            self.units["presence_ratio"],
+            np.linspace(0, 1, 100),
+            "Presence ratio",
+            vline=0.9,
+        )
+
+    def amp_cutoff_plot(self):
+        return self._plot_metric(
+            self.units["amplitude_cutoff"],
+            np.linspace(0, 0.5, 200),
+            "Amplitude cutoff",
+            vline=0.1,
+        )
+
+    def isi_violation_plot(self):
+        return self._plot_metric(
+            np.log10(self.units["isi_violation"] + 1e-5),  # Offset b/c log(0)
+            np.linspace(-6, 2.5, 100),  # If linear np.linspace(0, 10, 200)
+            "log<sub>10</sub> ISI violations",
+            vline=np.log10(0.5),
+        )
+
+    def snr_plot(self):
+        return self._plot_metric(self.units["snr"], np.linspace(0, 10, 100), "SNR")
+
+    def iso_dist_plot(self):
+        return self._plot_metric(
+            self.units["isolation_distance"],
+            np.linspace(0, 170, 50),
+            "Isolation distance",
+        )
+
+    def d_prime_plot(self):
+        return self._plot_metric(
+            self.units["d_prime"], np.linspace(0, 15, 50), "d-prime"
+        )
+
+    def nn_hit_plot(self):
+        return self._plot_metric(
+            self.units["nn_hit_rate"],
+            np.linspace(0, 1, 100),
+            "Nearest-neighbors hit rate",
+        )

--- a/element_array_ephys/plotting/qc.py
+++ b/element_array_ephys/plotting/qc.py
@@ -150,7 +150,7 @@ class QualityMetricFigs(object):
             fig = go.Figure()
         if not scale:
             scale = self._scale
-        width = self._fig_width * scale  # ctrl for scale @ init, likel
+        width = self._fig_width * scale
         return fig.update_layout(
             template="plotly_dark" if self._dark_mode else "simple_white",
             width=width,

--- a/element_array_ephys/plotting/qc.py
+++ b/element_array_ephys/plotting/qc.py
@@ -1,9 +1,9 @@
+import logging
+import types
+
 import numpy as np
 import pandas as pd
-import datajoint as dj
-import logging
 import plotly.graph_objs as go
-import types
 from scipy.ndimage import gaussian_filter1d
 
 from .. import ephys_report

--- a/element_array_ephys/plotting/qc.py
+++ b/element_array_ephys/plotting/qc.py
@@ -83,30 +83,23 @@ class QualityMetricFigs(object):
         )
 
     @cutoffs.setter
-    def cutoffs(self, add_to_tables: bool = False, **cutoff_kwargs):
+    def cutoffs(self, cutoff_dict):
         """Use class_instance.cutoffs = dict(var=cutoff) to adjust cutoffs
 
-        If add_to_tables=True, adds to the QualityMetricCutoffs/Set tables
-
         Args:
-            add_to_tables (bool, optional): add to ephys_report tables. Default False
-            cutoff_kwargs (kwargs): Cutoffs to adjust: amplitude_cutoff_maximum,
+            cutoff_dict (kwargs): Cutoffs to adjust: amplitude_cutoff_maximum,
                 presence_ratio_minimum, and/or isi_violations_maximum
         """
-        self._amplitude_cutoff_max = cutoff_kwargs.get(
+        self._amplitude_cutoff_max = cutoff_dict.get(
             "amplitude_cutoff_maximum", self._amplitude_cutoff_max
         )
-        self._presence_ratio_min = cutoff_kwargs.get(
+        self._presence_ratio_min = cutoff_dict.get(
             "presence_ratio_minimum", self._presence_ratio_min
         )
-        self._isi_violations_max = cutoff_kwargs.get(
+        self._isi_violations_max = cutoff_dict.get(
             "isi_violations_maximum", self._isi_violations_max
         )
         _ = self.units
-
-        if add_to_tables:
-            ephys_report.QualityMetricCutoffs.insert_new_cutoffs(**cutoff_kwargs)
-            logger.info("Added cutoffs to QualityMetricCutoffs table")
 
     @property
     def units(self) -> pd.DataFrame:

--- a/element_array_ephys/plotting/unit_level.py
+++ b/element_array_ephys/plotting/unit_level.py
@@ -26,7 +26,7 @@ def plot_waveform(waveform: np.ndarray, sampling_rate: float) -> go.Figure:
             x=waveform_df["timestamp"],
             y=waveform_df["waveform"],
             mode="lines",
-            line=dict(color="rgb(51, 76.5, 204)", width=2),
+            line=dict(color="rgb(0, 160, 223)", width=2),  # DataJoint Blue
             hovertemplate="%{y:.2f} μV<br>" + "%{x:.2f} ms<extra></extra>",
         )
     )

--- a/element_array_ephys/plotting/widget.py
+++ b/element_array_ephys/plotting/widget.py
@@ -3,8 +3,6 @@ from skimage import io
 import types
 from ipywidgets import widgets
 from IPython.display import display
-from plotly.io import from_json
-from plotly.subplots import make_subplots
 import plotly.graph_objs as go
 import plotly.express as px
 

--- a/element_array_ephys/plotting/widget.py
+++ b/element_array_ephys/plotting/widget.py
@@ -1,8 +1,7 @@
 import pathlib
 from skimage import io
-from modulefinder import Module
-import ipywidgets as widgets
-from ipywidgets import widgets as wg
+import types
+from ipywidgets import widgets
 from IPython.display import display
 from plotly.io import from_json
 from plotly.subplots import make_subplots
@@ -12,7 +11,7 @@ import plotly.express as px
 from .. import ephys_report
 
 
-def main(ephys: Module) -> widgets:
+def main(ephys: types.ModuleType) -> widgets:
 
     # Build dropdown widgets
     probe_dropdown_wg = widgets.Dropdown(
@@ -127,125 +126,3 @@ def main(ephys: Module) -> widgets:
     unit_widget = widgets.interactive(plot_unit_widget, unit=unit_dropdown_wg)
 
     return widgets.VBox([probe_widget, unit_widget])
-
-
-def qc_widget(ephys: Module) -> widgets:
-    from .qc import QualityMetricFigs
-
-    title_button = wg.Button(
-        description="Ephys Quality Control Metrics",
-        button_style="info",
-        layout=wg.Layout(
-            height="auto", width="auto", grid_area="title_button", border="solid"
-        ),
-        style=wg.ButtonStyle(button_color="#00a0df"),
-        disabled=True,
-    )
-
-    cluster_dropdown = wg.Dropdown(
-        options=ephys.QualityMetrics.fetch("KEY"),
-        description="Clusters:",
-        description_tooltip='Press "Load" to visualize the clusters identified.',
-        disabled=False,
-        layout=wg.Layout(
-            width="95%",
-            display="flex",
-            flex_flow="row",
-            justify_content="space-between",
-            grid_area="cluster_dropdown",
-        ),
-        style={"description_width": "80px"},
-    )
-
-    cutoff_dropdown = wg.Dropdown(
-        options=ephys_report.QualityMetricCutoffs.fetch("KEY"),
-        description="Cutoffs:",
-        description_tooltip='Press "Load" to visualize the clusters identified.',
-        disabled=False,
-        layout=wg.Layout(
-            width="95%",
-            display="flex",
-            flex_flow="row",
-            justify_content="space-between",
-            grid_area="cutoff_dropdown",
-        ),
-        style={"description_width": "80px"},
-    )
-
-    fig = make_subplots(
-        rows=1,
-        cols=2,
-        shared_yaxes=False,
-        horizontal_spacing=0.01,
-        vertical_spacing=0,
-        column_titles=["Firing", "Title2"],
-    )
-    fwg = go.FigureWidget(fig)
-
-    # figure_output = wg.VBox(
-    #     [QualityMetricFigs.empty_fig()],
-    #     layout=wg.Layout(width="95%", grid_area="figure_output"),
-    # )
-    # figure_output.add_class("box_style")
-
-    load_button = wg.Button(
-        description="Load",
-        tooltip="Load figures.",
-        layout=wg.Layout(width="auto", grid_area="load_button"),
-    )
-
-    def response(change, usedb=False):  # TODO: Accept cutoff vals?
-        global firing_rate_plot
-        if usedb:
-            if cluster_dropdown.value not in ephys_report.QualityMetricReport():
-                ephys_report.QualityMetricReport.populate(cluster_dropdown.value)
-
-            firing_rate_plot = from_json(
-                (ephys_report.QualityMetricReport & cluster_dropdown.value).fetch1(
-                    "firing_rate_plot"
-                )
-            )
-
-            presence_ratio_plot = from_json(
-                (ephys_report.QualityMetricReport & cluster_dropdown.value).fetch1(
-                    "presence_ratio_plot"
-                )
-            )
-
-        else:
-            qc_figs = QualityMetricFigs(cluster_dropdown)
-            firing_rate_plot = qc_figs.empty_fig()
-            presence_ratio_plot = qc_figs.empty_fig()
-
-        with fwg.batch_update():
-            fwg.data[0] = firing_rate_plot
-            fwg.data[1] = presence_ratio_plot
-
-    figure_output = wg.VBox(
-        [fwg], layout=wg.Layout(width="95%", grid_area="figure_output")
-    )
-    figure_output.add_class("box_style")
-
-    load_button.on_click(response)
-
-    main_container = wg.GridBox(
-        children=[
-            title_button,
-            cluster_dropdown,
-            cutoff_dropdown,
-            load_button,
-            figure_output,
-        ],
-        layout=wg.Layout(
-            grid_template_areas="""
-            "title_button title_button title_button"
-            "cluster_dropdown . load_button"
-            "cutoff_dropdown . load_button"
-            "figure_output figure_output figure_output"
-            """
-        ),
-        grid_template_rows="auto auto auto auto",
-        grid_template_columns="auto auto auto",
-    )
-
-    return main_container

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
### Submission checklist

- [X] Reviewed all `Files changed` prior to selecting `Create Pull Request`.
- [X] Ran pipeline, but not pytests as no pytests exist for added features
- [X] Ran pre-commit checks, including black, flake8, etc. (on newly added files)
- [X] Updated the changelog and if making a new release, updated the version.py.
- [ ] Updated documentation, including concepts.md, tutorials.md, and relevant docstrings.
   - Skipping for now, as @kushalbakshi plans to do a deep dive on QC metrics
- [X] After merge, I will push a new tag to upstream (test* prefix if no new release).

### Submission details

In this pull request, I make the following changes:
- Concept: add temp* prefix to gitignore to skip notes files
- Concept: Minor edits to existing dashboard/plotting
   - unit_level.py: Change existing line color to DataJoint blue
   - widget.py: Fix typing suggestion for datajoint module and sort imports (isort)
- Concept: Add QC dashboard to provide plotly figures. Examples:  
   - Generate grid from a given key: ![qc_plots_2](https://user-images.githubusercontent.com/9404707/209008607-c54f428c-6e56-4c84-a7c2-f8e2fd5fc739.png)
   - Generate one plot, resize, get coordinates from tooltip: ![Screen Shot 2022-12-21 at 15 53 12](https://user-images.githubusercontent.com/9404707/209009172-d943b709-7cb5-48fd-a7e0-1ef57d46597e.png)
   - Add a new plot on the fly: ![qc_plots_1](https://user-images.githubusercontent.com/9404707/209008596-5e161983-b3a3-4610-845f-9ae2de1c2c33.png)

### Other notes

A new class method in `ephys_report` depends on [element-interface 43](https://github.com/datajoint/element-interface/pull/43). If this cannot get merged first, this class method should be adjusted accordingly