### PR TITLE
Docstring changes for docs API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 ## [0.2.2] - Unreleased
 
 + Bugfix - Update docstrings to render API for documentation website.
-## [0.2.1] - Unreleased
 
+## [0.2.1] - 2022-01-06
+
++ Add - `build_electrode_layouts` function in `probe.py` to compute the electrode layout for all types of probes.
++ Update - parameterize run_CatGT step from parameters retrieved from `ClusteringParamSet` table
 + Update - clustering step, update duration for "median_subtraction" step
 + Bugfix - handles single probe recording in "Neuropix-PXI" format
 + Update - safeguard in creating/inserting probe types upon probe activation
 + Add - quality control metric dashboard
++ Update & fix docstrings
++ Update - `ephys_report.UnitLevelReport` to add `ephys.ClusterQualityLabel` as a foreign key reference
++ Add - `.pre-commit-config.yaml`
 
 ## [0.2.0] - 2022-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
  [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.2.2] - Unreleased
+
++ Bugfix - Update docstrings to render API for documentation website.
 ## [0.2.1] - Unreleased
 
 + Update - clustering step, update duration for "median_subtraction" step
@@ -61,6 +64,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - Probe table supporting: Neuropixels probes 1.0 - 3A, 1.0 - 3B, 2.0 - SS,
   2.0 - MS
 
+[0.2.2]: https://github.com/datajoint/element-array-ephys/releases/tag/0.2.2
 [0.2.1]: https://github.com/datajoint/element-array-ephys/releases/tag/0.2.1
 [0.2.0]: https://github.com/datajoint/element-array-ephys/releases/tag/0.2.0
 [0.1.4]: https://github.com/datajoint/element-array-ephys/releases/tag/0.1.4

--- a/element_array_ephys/ephys_acute.py
+++ b/element_array_ephys/ephys_acute.py
@@ -185,7 +185,8 @@ class ProbeInsertion(dj.Manual):
 
                 probe_dir = meta_filepath.parent
                 try:
-                    probe_number = re.search("(imec)?\d{1}$", probe_dir.name).group()
+                    probe_number = re.search(
+                        "(imec)?\d{1}$", probe_dir.name).group()
                     probe_number = int(probe_number.replace("imec", ""))
                 except AttributeError:
                     probe_number = meta_fp_idx
@@ -214,7 +215,8 @@ class ProbeInsertion(dj.Manual):
                     }
                 )
         else:
-            raise NotImplementedError(f"Unknown acquisition software: {acq_software}")
+            raise NotImplementedError(
+                f"Unknown acquisition software: {acq_software}")
 
         probe.Probe.insert(probe_list, skip_duplicates=True)
         cls.insert(probe_insertion_list, skip_duplicates=True)
@@ -231,8 +233,7 @@ class InsertionLocation(dj.Manual):
         ml_location (decimal (6, 2) ): Medial-lateral location in micrometers. Reference is zero with right side values positive.
         depth (decimal (6, 2) ): Manipulator depth relative to the surface of the brain at zero. Ventral is negative.
         Theta (decimal (5, 2) ): elevation - rotation about the ml-axis in degrees relative to positive z-axis.
-        phi (decimal (5, 2) ): azimuth - rotation about the dv-axis in degrees relative to the positive x-axis
-
+        phi (decimal (5, 2) ): azimuth - rotation about the dv-axis in degrees relative to the positive x-axis.
     """
 
     definition = """
@@ -322,12 +323,14 @@ class EphysRecording(dj.Imported):
                     break
             else:
                 raise FileNotFoundError(
-                    "No SpikeGLX data found for probe insertion: {}".format(key)
+                    "No SpikeGLX data found for probe insertion: {}".format(
+                        key)
                 )
 
             if spikeglx_meta.probe_model in supported_probe_types:
                 probe_type = spikeglx_meta.probe_model
-                electrode_query = probe.ProbeType.Electrode & {"probe_type": probe_type}
+                electrode_query = probe.ProbeType.Electrode & {
+                    "probe_type": probe_type}
 
                 probe_electrodes = {
                     (shank, shank_col, shank_row): key
@@ -360,9 +363,11 @@ class EphysRecording(dj.Imported):
                 }
             )
 
-            root_dir = find_root_directory(get_ephys_root_data_dir(), meta_filepath)
+            root_dir = find_root_directory(
+                get_ephys_root_data_dir(), meta_filepath)
             self.EphysFile.insert1(
-                {**key, "file_path": meta_filepath.relative_to(root_dir).as_posix()}
+                {**key,
+                    "file_path": meta_filepath.relative_to(root_dir).as_posix()}
             )
         elif acq_software == "Open Ephys":
             dataset = openephys.OpenEphys(session_dir)
@@ -371,7 +376,8 @@ class EphysRecording(dj.Imported):
                     break
             else:
                 raise FileNotFoundError(
-                    "No Open Ephys data found for probe insertion: {}".format(key)
+                    "No Open Ephys data found for probe insertion: {}".format(
+                        key)
                 )
 
             if not probe_data.ap_meta:
@@ -381,7 +387,8 @@ class EphysRecording(dj.Imported):
 
             if probe_data.probe_model in supported_probe_types:
                 probe_type = probe_data.probe_model
-                electrode_query = probe.ProbeType.Electrode & {"probe_type": probe_type}
+                electrode_query = probe.ProbeType.Electrode & {
+                    "probe_type": probe_type}
 
                 probe_electrodes = {
                     key["electrode"]: key for key in electrode_query.fetch("KEY")
@@ -394,7 +401,8 @@ class EphysRecording(dj.Imported):
             else:
                 raise NotImplementedError(
                     "Processing for neuropixels"
-                    " probe model {} not yet implemented".format(probe_data.probe_model)
+                    " probe model {} not yet implemented".format(
+                        probe_data.probe_model)
                 )
 
             self.insert1(
@@ -456,7 +464,7 @@ class LFP(dj.Imported):
 
     class Electrode(dj.Part):
         """Saves local field potential data for each electrode.
-
+        
         Attributes:
             LFP (foreign key): LFP primary key.
             probe.ElectrodeConfig.Electrode (foreign key): probe.ElectrodeConfig.Electrode primary key.
@@ -476,16 +484,18 @@ class LFP(dj.Imported):
 
     def make(self, key):
         """Populates the LFP tables."""
-        acq_software = (EphysRecording * ProbeInsertion & key).fetch1("acq_software")
+        acq_software = (EphysRecording * ProbeInsertion &
+                        key).fetch1("acq_software")
 
         electrode_keys, lfp = [], []
 
         if acq_software == "SpikeGLX":
             spikeglx_meta_filepath = get_spikeglx_meta_filepath(key)
-            spikeglx_recording = spikeglx.SpikeGLX(spikeglx_meta_filepath.parent)
+            spikeglx_recording = spikeglx.SpikeGLX(
+                spikeglx_meta_filepath.parent)
 
             lfp_channel_ind = spikeglx_recording.lfmeta.recording_channels[
-                -1 :: -self._skip_channel_counts
+                -1:: -self._skip_channel_counts
             ]
 
             # Extract LFP data at specified channels and convert to uV
@@ -493,7 +503,8 @@ class LFP(dj.Imported):
                 :, lfp_channel_ind
             ]  # (sample x channel)
             lfp = (
-                lfp * spikeglx_recording.get_channel_bit_volts("lf")[lfp_channel_ind]
+                lfp *
+                spikeglx_recording.get_channel_bit_volts("lf")[lfp_channel_ind]
             ).T  # (channel x sample)
 
             self.insert1(
@@ -525,18 +536,21 @@ class LFP(dj.Imported):
                 shank, shank_col, shank_row, _ = spikeglx_recording.apmeta.shankmap[
                     "data"
                 ][recorded_site]
-                electrode_keys.append(probe_electrodes[(shank, shank_col, shank_row)])
+                electrode_keys.append(
+                    probe_electrodes[(shank, shank_col, shank_row)])
         elif acq_software == "Open Ephys":
             oe_probe = get_openephys_probe_data(key)
 
             lfp_channel_ind = np.r_[
                 len(oe_probe.lfp_meta["channels_indices"])
-                - 1 : 0 : -self._skip_channel_counts
+                - 1: 0: -self._skip_channel_counts
             ]
 
-            lfp = oe_probe.lfp_timeseries[:, lfp_channel_ind]  # (sample x channel)
+            # (sample x channel)
+            lfp = oe_probe.lfp_timeseries[:, lfp_channel_ind]
             lfp = (
-                lfp * np.array(oe_probe.lfp_meta["channels_gains"])[lfp_channel_ind]
+                lfp *
+                np.array(oe_probe.lfp_meta["channels_gains"])[lfp_channel_ind]
             ).T  # (channel x sample)
             lfp_timestamps = oe_probe.lfp_timestamps
 
@@ -608,7 +622,7 @@ class ClusteringParamSet(dj.Lookup):
         ClusteringMethod (dict): ClusteringMethod primary key.
         paramset_desc (varchar(128) ): Description of the clustering parameter set.
         param_set_hash (uuid): UUID hash for the parameter set.
-        params (longblob)
+        params (longblob): Parameters for clustering with Kilosort.
     """
 
     definition = """
@@ -764,7 +778,8 @@ class ClusteringTask(dj.Manual):
         key = {**ephys_recording_key, "paramset_idx": paramset_idx}
 
         processed_dir = get_processed_root_data_dir()
-        output_dir = ClusteringTask.infer_output_dir(key, relative=False, mkdir=True)
+        output_dir = ClusteringTask.infer_output_dir(
+            key, relative=False, mkdir=True)
 
         try:
             kilosort.Kilosort(
@@ -811,7 +826,8 @@ class Clustering(dj.Imported):
         )
 
         if not output_dir:
-            output_dir = ClusteringTask.infer_output_dir(key, relative=True, mkdir=True)
+            output_dir = ClusteringTask.infer_output_dir(
+                key, relative=True, mkdir=True)
             # update clustering_output_dir
             ClusteringTask.update1(
                 {**key, "clustering_output_dir": output_dir.as_posix()}
@@ -1018,7 +1034,8 @@ class CuratedClustering(dj.Imported):
             "acq_software", "sampling_rate"
         )
 
-        sample_rate = kilosort_dataset.data["params"].get("sample_rate", sample_rate)
+        sample_rate = kilosort_dataset.data["params"].get(
+            "sample_rate", sample_rate)
 
         # ---------- Unit ----------
         # -- Remove 0-spike units
@@ -1030,7 +1047,8 @@ class CuratedClustering(dj.Imported):
         valid_units = kilosort_dataset.data["cluster_ids"][withspike_idx]
         valid_unit_labels = kilosort_dataset.data["cluster_groups"][withspike_idx]
         # -- Get channel and electrode-site mapping
-        channel2electrodes = get_neuropixels_channel2electrode_map(key, acq_software)
+        channel2electrodes = get_neuropixels_channel2electrode_map(
+            key, acq_software)
 
         # -- Spike-times --
         # spike_times_sec_adj > spike_times_sec > spike_times
@@ -1197,7 +1215,8 @@ class WaveformSet(dj.Imported):
         else:
             if acq_software == "SpikeGLX":
                 spikeglx_meta_filepath = get_spikeglx_meta_filepath(key)
-                neuropixels_recording = spikeglx.SpikeGLX(spikeglx_meta_filepath.parent)
+                neuropixels_recording = spikeglx.SpikeGLX(
+                    spikeglx_meta_filepath.parent)
             elif acq_software == "Open Ephys":
                 session_dir = find_full_path(
                     get_ephys_root_data_dir(), get_session_directory(key)
@@ -1245,9 +1264,11 @@ class WaveformSet(dj.Imported):
         self.insert1(key)
         for unit_peak_waveform, unit_electrode_waveforms in yield_unit_waveforms():
             if unit_peak_waveform:
-                self.PeakWaveform.insert1(unit_peak_waveform, ignore_extra_fields=True)
+                self.PeakWaveform.insert1(
+                    unit_peak_waveform, ignore_extra_fields=True)
             if unit_electrode_waveforms:
-                self.Waveform.insert(unit_electrode_waveforms, ignore_extra_fields=True)
+                self.Waveform.insert(
+                    unit_electrode_waveforms, ignore_extra_fields=True)
 
 
 @schema
@@ -1392,7 +1413,8 @@ def get_spikeglx_meta_filepath(ephys_recording_key: dict) -> str:
                 ProbeInsertion * probe.Probe & ephys_recording_key
             ).fetch1("probe")
 
-            spikeglx_meta_filepaths = [fp for fp in session_dir.rglob("*.ap.meta")]
+            spikeglx_meta_filepaths = [
+                fp for fp in session_dir.rglob("*.ap.meta")]
             for meta_filepath in spikeglx_meta_filepaths:
                 spikeglx_meta = spikeglx.SpikeGLXMeta(meta_filepath)
                 if str(spikeglx_meta.probe_SN) == inserted_probe_serial_number:
@@ -1432,7 +1454,8 @@ def get_neuropixels_channel2electrode_map(
 ) -> dict:
     """Get the channel map for neuropixels probe."""
     if acq_software == "SpikeGLX":
-        spikeglx_meta_filepath = get_spikeglx_meta_filepath(ephys_recording_key)
+        spikeglx_meta_filepath = get_spikeglx_meta_filepath(
+            ephys_recording_key)
         spikeglx_meta = spikeglx.SpikeGLXMeta(spikeglx_meta_filepath)
         electrode_config_key = (
             EphysRecording * probe.ElectrodeConfig & ephys_recording_key
@@ -1487,7 +1510,8 @@ def generate_electrode_config(probe_type: str, electrode_keys: list) -> dict:
         dict: representing a key of the probe.ElectrodeConfig table
     """
     # compute hash for the electrode config (hash of dict of all ElectrodeConfig.Electrode)
-    electrode_config_hash = dict_to_uuid({k["electrode"]: k for k in electrode_keys})
+    electrode_config_hash = dict_to_uuid(
+        {k["electrode"]: k for k in electrode_keys})
 
     electrode_list = sorted([k["electrode"] for k in electrode_keys])
     electrode_gaps = (
@@ -1557,9 +1581,11 @@ def get_recording_channels_details(ephys_recording_key: dict) -> np.array:
     channels_details["num_channels"] = len(channels_details["channel_ind"])
 
     if acq_software == "SpikeGLX":
-        spikeglx_meta_filepath = get_spikeglx_meta_filepath(ephys_recording_key)
+        spikeglx_meta_filepath = get_spikeglx_meta_filepath(
+            ephys_recording_key)
         spikeglx_recording = spikeglx.SpikeGLX(spikeglx_meta_filepath.parent)
-        channels_details["uVPerBit"] = spikeglx_recording.get_channel_bit_volts("ap")[0]
+        channels_details["uVPerBit"] = spikeglx_recording.get_channel_bit_volts("ap")[
+            0]
         channels_details["connected"] = np.array(
             [v for *_, v in spikeglx_recording.apmeta.shankmap["data"]]
         )

--- a/element_array_ephys/ephys_chronic.py
+++ b/element_array_ephys/ephys_chronic.py
@@ -163,8 +163,7 @@ class InsertionLocation(dj.Manual):
         ml_location (decimal (6, 2) ): Medial-lateral location in micrometers. Reference is zero with right side values positive.
         depth (decimal (6, 2) ): Manipulator depth relative to the surface of the brain at zero. Ventral is negative.
         Theta (decimal (5, 2) ): elevation - rotation about the ml-axis in degrees relative to positive z-axis.
-        phi (decimal (5, 2) ): azimuth - rotation about the dv-axis in degrees relative to the positive x-axis
-
+        phi (decimal (5, 2) ): azimuth - rotation about the dv-axis in degrees relative to the positive x-axis.
     """
 
     definition = """
@@ -261,7 +260,8 @@ class EphysRecording(dj.Imported):
 
             if spikeglx_meta.probe_model in supported_probe_types:
                 probe_type = spikeglx_meta.probe_model
-                electrode_query = probe.ProbeType.Electrode & {"probe_type": probe_type}
+                electrode_query = probe.ProbeType.Electrode & {
+                    "probe_type": probe_type}
 
                 probe_electrodes = {
                     (shank, shank_col, shank_row): key
@@ -294,9 +294,11 @@ class EphysRecording(dj.Imported):
                 }
             )
 
-            root_dir = find_root_directory(get_ephys_root_data_dir(), meta_filepath)
+            root_dir = find_root_directory(
+                get_ephys_root_data_dir(), meta_filepath)
             self.EphysFile.insert1(
-                {**key, "file_path": meta_filepath.relative_to(root_dir).as_posix()}
+                {**key,
+                    "file_path": meta_filepath.relative_to(root_dir).as_posix()}
             )
         elif acq_software == "Open Ephys":
             dataset = openephys.OpenEphys(session_dir)
@@ -305,7 +307,8 @@ class EphysRecording(dj.Imported):
                     break
             else:
                 raise FileNotFoundError(
-                    "No Open Ephys data found for probe insertion: {}".format(key)
+                    "No Open Ephys data found for probe insertion: {}".format(
+                        key)
                 )
 
             if not probe_data.ap_meta:
@@ -315,7 +318,8 @@ class EphysRecording(dj.Imported):
 
             if probe_data.probe_model in supported_probe_types:
                 probe_type = probe_data.probe_model
-                electrode_query = probe.ProbeType.Electrode & {"probe_type": probe_type}
+                electrode_query = probe.ProbeType.Electrode & {
+                    "probe_type": probe_type}
 
                 probe_electrodes = {
                     key["electrode"]: key for key in electrode_query.fetch("KEY")
@@ -328,7 +332,8 @@ class EphysRecording(dj.Imported):
             else:
                 raise NotImplementedError(
                     "Processing for neuropixels"
-                    " probe model {} not yet implemented".format(probe_data.probe_model)
+                    " probe model {} not yet implemented".format(
+                        probe_data.probe_model)
                 )
 
             self.insert1(
@@ -390,7 +395,7 @@ class LFP(dj.Imported):
 
     class Electrode(dj.Part):
         """Saves local field potential data for each electrode.
-
+        
         Attributes:
             LFP (foreign key): LFP primary key.
             probe.ElectrodeConfig.Electrode (foreign key): probe.ElectrodeConfig.Electrode primary key.
@@ -410,16 +415,18 @@ class LFP(dj.Imported):
 
     def make(self, key):
         """Populates the LFP tables."""
-        acq_software = (EphysRecording * ProbeInsertion & key).fetch1("acq_software")
+        acq_software = (EphysRecording * ProbeInsertion &
+                        key).fetch1("acq_software")
 
         electrode_keys, lfp = [], []
 
         if acq_software == "SpikeGLX":
             spikeglx_meta_filepath = get_spikeglx_meta_filepath(key)
-            spikeglx_recording = spikeglx.SpikeGLX(spikeglx_meta_filepath.parent)
+            spikeglx_recording = spikeglx.SpikeGLX(
+                spikeglx_meta_filepath.parent)
 
             lfp_channel_ind = spikeglx_recording.lfmeta.recording_channels[
-                -1 :: -self._skip_channel_counts
+                -1:: -self._skip_channel_counts
             ]
 
             # Extract LFP data at specified channels and convert to uV
@@ -427,7 +434,8 @@ class LFP(dj.Imported):
                 :, lfp_channel_ind
             ]  # (sample x channel)
             lfp = (
-                lfp * spikeglx_recording.get_channel_bit_volts("lf")[lfp_channel_ind]
+                lfp *
+                spikeglx_recording.get_channel_bit_volts("lf")[lfp_channel_ind]
             ).T  # (channel x sample)
 
             self.insert1(
@@ -459,18 +467,21 @@ class LFP(dj.Imported):
                 shank, shank_col, shank_row, _ = spikeglx_recording.apmeta.shankmap[
                     "data"
                 ][recorded_site]
-                electrode_keys.append(probe_electrodes[(shank, shank_col, shank_row)])
+                electrode_keys.append(
+                    probe_electrodes[(shank, shank_col, shank_row)])
         elif acq_software == "Open Ephys":
             oe_probe = get_openephys_probe_data(key)
 
             lfp_channel_ind = np.r_[
                 len(oe_probe.lfp_meta["channels_indices"])
-                - 1 : 0 : -self._skip_channel_counts
+                - 1: 0: -self._skip_channel_counts
             ]
 
-            lfp = oe_probe.lfp_timeseries[:, lfp_channel_ind]  # (sample x channel)
+            # (sample x channel)
+            lfp = oe_probe.lfp_timeseries[:, lfp_channel_ind]
             lfp = (
-                lfp * np.array(oe_probe.lfp_meta["channels_gains"])[lfp_channel_ind]
+                lfp *
+                np.array(oe_probe.lfp_meta["channels_gains"])[lfp_channel_ind]
             ).T  # (channel x sample)
             lfp_timestamps = oe_probe.lfp_timestamps
 
@@ -542,7 +553,7 @@ class ClusteringParamSet(dj.Lookup):
         ClusteringMethod (dict): ClusteringMethod primary key.
         paramset_desc (varchar(128) ): Description of the clustering parameter set.
         param_set_hash (uuid): UUID hash for the parameter set.
-        params (longblob)
+        params (longblob): Parameters for clustering with Kilosort.
     """
 
     definition = """
@@ -663,7 +674,8 @@ class ClusteringTask(dj.Manual):
             e.g.: sub4/sess1/probe_2/kilosort2_0
         """
         processed_dir = pathlib.Path(get_processed_root_data_dir())
-        sess_dir = find_full_path(get_ephys_root_data_dir(), get_session_directory(key))
+        sess_dir = find_full_path(
+            get_ephys_root_data_dir(), get_session_directory(key))
         root_dir = find_root_directory(get_ephys_root_data_dir(), sess_dir)
 
         method = (
@@ -696,7 +708,8 @@ class ClusteringTask(dj.Manual):
         key = {**ephys_recording_key, "paramset_idx": paramset_idx}
 
         processed_dir = get_processed_root_data_dir()
-        output_dir = ClusteringTask.infer_output_dir(key, relative=False, mkdir=True)
+        output_dir = ClusteringTask.infer_output_dir(
+            key, relative=False, mkdir=True)
 
         try:
             kilosort.Kilosort(
@@ -743,7 +756,8 @@ class Clustering(dj.Imported):
         )
 
         if not output_dir:
-            output_dir = ClusteringTask.infer_output_dir(key, relative=True, mkdir=True)
+            output_dir = ClusteringTask.infer_output_dir(
+                key, relative=True, mkdir=True)
             # update clustering_output_dir
             ClusteringTask.update1(
                 {**key, "clustering_output_dir": output_dir.as_posix()}
@@ -950,7 +964,8 @@ class CuratedClustering(dj.Imported):
             "acq_software", "sampling_rate"
         )
 
-        sample_rate = kilosort_dataset.data["params"].get("sample_rate", sample_rate)
+        sample_rate = kilosort_dataset.data["params"].get(
+            "sample_rate", sample_rate)
 
         # ---------- Unit ----------
         # -- Remove 0-spike units
@@ -962,7 +977,8 @@ class CuratedClustering(dj.Imported):
         valid_units = kilosort_dataset.data["cluster_ids"][withspike_idx]
         valid_unit_labels = kilosort_dataset.data["cluster_groups"][withspike_idx]
         # -- Get channel and electrode-site mapping
-        channel2electrodes = get_neuropixels_channel2electrode_map(key, acq_software)
+        channel2electrodes = get_neuropixels_channel2electrode_map(
+            key, acq_software)
 
         # -- Spike-times --
         # spike_times_sec_adj > spike_times_sec > spike_times
@@ -1129,7 +1145,8 @@ class WaveformSet(dj.Imported):
         else:
             if acq_software == "SpikeGLX":
                 spikeglx_meta_filepath = get_spikeglx_meta_filepath(key)
-                neuropixels_recording = spikeglx.SpikeGLX(spikeglx_meta_filepath.parent)
+                neuropixels_recording = spikeglx.SpikeGLX(
+                    spikeglx_meta_filepath.parent)
             elif acq_software == "Open Ephys":
                 session_dir = find_full_path(
                     get_ephys_root_data_dir(), get_session_directory(key)
@@ -1177,9 +1194,11 @@ class WaveformSet(dj.Imported):
         self.insert1(key)
         for unit_peak_waveform, unit_electrode_waveforms in yield_unit_waveforms():
             if unit_peak_waveform:
-                self.PeakWaveform.insert1(unit_peak_waveform, ignore_extra_fields=True)
+                self.PeakWaveform.insert1(
+                    unit_peak_waveform, ignore_extra_fields=True)
             if unit_electrode_waveforms:
-                self.Waveform.insert(unit_electrode_waveforms, ignore_extra_fields=True)
+                self.Waveform.insert(
+                    unit_electrode_waveforms, ignore_extra_fields=True)
 
 
 @schema
@@ -1324,7 +1343,8 @@ def get_spikeglx_meta_filepath(ephys_recording_key: dict) -> str:
                 ProbeInsertion * probe.Probe & ephys_recording_key
             ).fetch1("probe")
 
-            spikeglx_meta_filepaths = [fp for fp in session_dir.rglob("*.ap.meta")]
+            spikeglx_meta_filepaths = [
+                fp for fp in session_dir.rglob("*.ap.meta")]
             for meta_filepath in spikeglx_meta_filepaths:
                 spikeglx_meta = spikeglx.SpikeGLXMeta(meta_filepath)
                 if str(spikeglx_meta.probe_SN) == inserted_probe_serial_number:
@@ -1364,7 +1384,8 @@ def get_neuropixels_channel2electrode_map(
 ) -> dict:
     """Get the channel map for neuropixels probe."""
     if acq_software == "SpikeGLX":
-        spikeglx_meta_filepath = get_spikeglx_meta_filepath(ephys_recording_key)
+        spikeglx_meta_filepath = get_spikeglx_meta_filepath(
+            ephys_recording_key)
         spikeglx_meta = spikeglx.SpikeGLXMeta(spikeglx_meta_filepath)
         electrode_config_key = (
             EphysRecording * probe.ElectrodeConfig & ephys_recording_key
@@ -1419,7 +1440,8 @@ def generate_electrode_config(probe_type: str, electrode_keys: list) -> dict:
         dict: representing a key of the probe.ElectrodeConfig table
     """
     # compute hash for the electrode config (hash of dict of all ElectrodeConfig.Electrode)
-    electrode_config_hash = dict_to_uuid({k["electrode"]: k for k in electrode_keys})
+    electrode_config_hash = dict_to_uuid(
+        {k["electrode"]: k for k in electrode_keys})
 
     electrode_list = sorted([k["electrode"] for k in electrode_keys])
     electrode_gaps = (
@@ -1489,9 +1511,11 @@ def get_recording_channels_details(ephys_recording_key: dict) -> np.array:
     channels_details["num_channels"] = len(channels_details["channel_ind"])
 
     if acq_software == "SpikeGLX":
-        spikeglx_meta_filepath = get_spikeglx_meta_filepath(ephys_recording_key)
+        spikeglx_meta_filepath = get_spikeglx_meta_filepath(
+            ephys_recording_key)
         spikeglx_recording = spikeglx.SpikeGLX(spikeglx_meta_filepath.parent)
-        channels_details["uVPerBit"] = spikeglx_recording.get_channel_bit_volts("ap")[0]
+        channels_details["uVPerBit"] = spikeglx_recording.get_channel_bit_volts("ap")[
+            0]
         channels_details["connected"] = np.array(
             [v for *_, v in spikeglx_recording.apmeta.shankmap["data"]]
         )

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
I've edited `ephys_acute.py` and `ephys_chronic.py` to test whether the docs API renders correctly for `InsertionLocation`, `ClusteringParamSet`, `Unit`, and `Electrode` tables. In local deployment, the API rendered without issues even before the changes were made, making it difficult to test the changes locally. 

If this results in rendering the API successfully, I will make these changes for all modules and tables that are not covered in this PR. 

Other changes to `ephys_acute.py` and `ephys_chronic.py` were performed by the Black formatter in VSCode.