### PR TITLE
Revert import order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
 
           # these are errors that will be ignored by flake8
           # https://www.flake8rules.com/rules/{code}.html
-          - "--ignore=E203,E501,W503,W605"
+          - "--ignore=E203,E501,W503,W605,E402"
           # E203 - Colons should not have any space before them.
           #        Needed for list indexing
           # E501 - Line lengths are recommended to be no greater than 79 characters.
@@ -54,3 +54,5 @@ repos:
           # W605 - a backslash-character pair that is not a valid escape sequence now
           #        generates a DeprecationWarning. This will eventually become a SyntaxError.
           #        Needed because we use \d as an escape sequence
+          # E402 - Place module level import at the top.
+          #        Needed to prevent circular import error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
  [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.2.2] - Unreleased
+
++ Bugfix - Revert import order in `__init__.py` to avoid circular import error.
++ Update - `.pre-commit-config.yaml` to disable automatic positioning of import statement at the top.
+
 ## [0.2.1] - 2022-01-06
 
 + Add - `build_electrode_layouts` function in `probe.py` to compute the electrode layout for all types of probes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 
 [0.2.2]: https://github.com/datajoint/element-array-ephys/releases/tag/0.2.2
+[0.2.1]: https://github.com/datajoint/element-array-ephys/releases/tag/0.2.1
+[0.2.0]: https://github.com/datajoint/element-array-ephys/releases/tag/0.2.0
 [0.1.4]: https://github.com/datajoint/element-array-ephys/releases/tag/0.1.4
 [0.1.3]: https://github.com/datajoint/element-array-ephys/releases/tag/0.1.3
 [0.1.2]: https://github.com/datajoint/element-array-ephys/releases/tag/0.1.2

--- a/element_array_ephys/__init__.py
+++ b/element_array_ephys/__init__.py
@@ -1,9 +1,12 @@
+"""
+isort:skip_file
+"""
+
 import logging
 import os
 
 import datajoint as dj
 
-from . import ephys_acute as ephys
 
 __all__ = ["ephys", "get_logger"]
 
@@ -14,3 +17,6 @@ def get_logger(name):
     log = logging.getLogger(name)
     log.setLevel(os.getenv("LOGLEVEL", "INFO"))
     return log
+
+
+from . import ephys_acute as ephys


### PR DESCRIPTION
- Revert import order in `__init__.py` to prevent circular import error and ignore automatic sorting for this file.
- Ignore flake E402 to allow for imports not always being placed at the top.