### PR TITLE
lowercase all column names in metrics.csv

### DIFF
--- a/element_array_ephys/ephys_acute.py
+++ b/element_array_ephys/ephys_acute.py
@@ -1360,7 +1360,7 @@ class QualityMetrics(dj.Imported):
         metrics_df = pd.read_csv(metric_fp)
         metrics_df.set_index("cluster_id", inplace=True)
         metrics_df.replace([np.inf, -np.inf], np.nan, inplace=True)
-
+        metrics_df.columns = metrics_df.columns.str.lower()
         metrics_list = [
             dict(metrics_df.loc[unit_key["unit"]], **unit_key)
             for unit_key in (CuratedClustering.Unit & key).fetch("KEY")

--- a/element_array_ephys/ephys_chronic.py
+++ b/element_array_ephys/ephys_chronic.py
@@ -1289,7 +1289,7 @@ class QualityMetrics(dj.Imported):
         metrics_df = pd.read_csv(metric_fp)
         metrics_df.set_index("cluster_id", inplace=True)
         metrics_df.replace([np.inf, -np.inf], np.nan, inplace=True)
-
+        metrics_df.columns = metrics_df.columns.str.lower()
         metrics_list = [
             dict(metrics_df.loc[unit_key["unit"]], **unit_key)
             for unit_key in (CuratedClustering.Unit & key).fetch("KEY")

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -1300,7 +1300,7 @@ class QualityMetrics(dj.Imported):
         metrics_df = pd.read_csv(metric_fp)
         metrics_df.set_index("cluster_id", inplace=True)
         metrics_df.replace([np.inf, -np.inf], np.nan, inplace=True)
-
+        metrics_df.columns = metrics_df.columns.str.lower()
         metrics_list = [
             dict(metrics_df.loc[unit_key["unit"]], **unit_key)
             for unit_key in (CuratedClustering.Unit & key).fetch("KEY")


### PR DESCRIPTION
- `pt_ratio` in `QualityMetrics.Waveform` is empty because it was named `PT_ratio` in the `metrics.csv`. The fix will change all column names to lowercase.