### PR TITLE
Fix readability of tables in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
  [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.2.10] - 2023-05-22
+## [0.2.10] - 2023-05-26
 
 + Add - Kilosort, NWB, and DANDI citations
++ Fix - CSS to improve readability of tables in dark mode
 + Update - mkdocs.yaml
 
 ## [0.2.9] - 2023-05-11

--- a/docs/src/.overrides/assets/stylesheets/extra.css
+++ b/docs/src/.overrides/assets/stylesheets/extra.css
@@ -92,7 +92,21 @@ html a[title="YouTube"].md-social__link svg {
     /* --md-footer-fg-color: var(--dj-white); */
 }
 
-[data-md-color-scheme="slate"] td,
-th {
-    color: var(--dj-black)
+table {
+    border-collapse: collapse;
+}
+
+tr {
+    border-left: 1px solid var(--dj-black);
+    border-right: 1px solid var(--dj-black);
+}
+
+td, th {
+    border-top: 1px solid var(--dj-black);
+    border-bottom: 1px solid var(--dj-black);
+}
+
+[data-md-color-scheme="slate"] td, th {
+    background-color: var(--dj-white);
+    color: var(--dj-black);
 }

--- a/docs/src/citation.md
+++ b/docs/src/citation.md
@@ -10,7 +10,7 @@ If your work uses the following resources, please cite the respective manuscript
   + [RRID:SCR_021894](https://scicrunch.org/resolver/SCR_021894)
 
 + Kilosort
-  + [Manuscripts](https://github.com/MouseLand/Kilosort#citation-requirement).
+  + [Manuscripts](https://github.com/MouseLand/Kilosort#citation-requirement)
 
 + NWB
   + [Manuscript](https://www.nwb.org/publications/)


### PR DESCRIPTION
The current CSS improves the readability of table queries in the Jupyter notebooks:
![image](https://github.com/datajoint/element-array-ephys/assets/871137/b7f69523-18ba-411a-a2da-1ea6f5386a51)

But now the standard markdown tables are not readable:
![image](https://github.com/datajoint/element-array-ephys/assets/871137/3f4501b5-fea5-46ab-a72a-3a3b4dc6a54c)

The proposed CSS changes fix the readability of the standard markdown tables, while for the most part keeping the styling of the table queries:
![image](https://github.com/datajoint/element-array-ephys/assets/871137/2c691725-eb40-4af1-a128-83fa20c822ee)
![image](https://github.com/datajoint/element-array-ephys/assets/871137/9eb33123-40a8-4b0a-a6c9-488676f240d8)

Once we merge this pull request, I will make these changes across all Elements.