### PR TITLE
fix(probe_geometry): bugfix in x_coords for probe with staggered electrode positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
  [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.3.2] - 2024-01-12
++ Fix - `probe_geometry` bugfix for incorrect handling of probes with staggered electrode positions
+
 ## [0.3.1] - 2023-11-28
 + Update - Flowchart borders for consistency with other DataJoint Elements
 + Fix - `dj.config()` setup moved to `tutorial_pipeline.py` instead of `__init__.py`

--- a/element_array_ephys/readers/probe_geometry.py
+++ b/element_array_ephys/readers/probe_geometry.py
@@ -188,7 +188,7 @@ def build_electrode_layouts(
         row_offset = np.zeros_like(x_coords)
     else:
         assert len(row_offset) == row_count
-        row_offset = np.tile(row_offset, col_count_per_shank)
+        row_offset = np.repeat(row_offset, col_count_per_shank)
     x_coords = x_coords + row_offset
 
     shank_cols = np.tile(range(col_count_per_shank), row_count)

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
Fix a bug in generating x_coords for electrodes from probes with staggered electrode position design (e.g. npx 3A and 3B)
This bug is new, from the recent updates to handle new SpikeGLX version
First reported by Janet Wallace from SabatiniLab