### PR TITLE
Minor change: remove pypi release from `release.yaml`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,14 +4,6 @@ on:
 jobs:
   make_github_release:
     uses: datajoint/.github/.github/workflows/make_github_release.yaml@main
-  pypi_release:
-    needs: make_github_release
-    uses: datajoint/.github/.github/workflows/pypi_release.yaml@main
-    secrets:
-      TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
-      TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
-    with:
-      UPLOAD_URL: ${{needs.make_github_release.outputs.release_upload_url}}
   mkdocs_release:
     uses: datajoint/.github/.github/workflows/mkdocs_release.yaml@main
     permissions: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
  [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.3.3] - 2024-01-24
++ Update - remove PyPi release from `release.yml` since it will fail after the new `setup.py`
+
 ## [0.3.2] - 2024-01-12
 + Fix - `probe_geometry` bugfix for incorrect handling of probes with staggered electrode positions
 

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.3.2"
+__version__ = "0.3.3"


### PR DESCRIPTION
Following the reviewer suggestion in this [PR review](https://github.com/datajoint/element-electrode-localization/pull/30), and to increase consistency with other DataJoint Elements, we remove the `pypi_release` from `release.yaml` file and update changelog and version.