### PR TITLE
Fix regex patterns and add minimum version for scikit-image

### DIFF
--- a/element_array_ephys/ephys_acute.py
+++ b/element_array_ephys/ephys_acute.py
@@ -185,7 +185,7 @@ class ProbeInsertion(dj.Manual):
 
                 probe_dir = meta_filepath.parent
                 try:
-                    probe_number = re.search("(imec)?\d{1}$", probe_dir.name).group()
+                    probe_number = re.search(r"(imec)?\d{1}$", probe_dir.name).group()
                     probe_number = int(probe_number.replace("imec", ""))
                 except AttributeError:
                     probe_number = meta_fp_idx

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -190,7 +190,7 @@ class ProbeInsertion(dj.Manual):
 
                 probe_dir = meta_filepath.parent
                 try:
-                    probe_number = re.search("(imec)?\d{1}$", probe_dir.name).group()
+                    probe_number = re.search(r"(imec)?\d{1}$", probe_dir.name).group()
                     probe_number = int(probe_number.replace("imec", ""))
                 except AttributeError:
                     probe_number = meta_fp_idx

--- a/element_array_ephys/readers/kilosort.py
+++ b/element_array_ephys/readers/kilosort.py
@@ -201,14 +201,14 @@ def extract_clustering_info(cluster_output_dir):
         is_curated = bool(np.any(curation_row))
         if creation_time is None and is_curated:
             row_meta = phylog.meta[np.where(curation_row)[0].max()]
-            datetime_str = re.search("\d{2}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}", row_meta)
+            datetime_str = re.search(r"\d{2}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}", row_meta)
             if datetime_str:
                 creation_time = datetime.strptime(
                     datetime_str.group(), "%Y-%m-%d %H:%M:%S"
                 )
             else:
                 creation_time = datetime.fromtimestamp(phylog_filepath.stat().st_ctime)
-                time_str = re.search("\d{2}:\d{2}:\d{2}", row_meta)
+                time_str = re.search(r"\d{2}:\d{2}:\d{2}", row_meta)
                 if time_str:
                     creation_time = datetime.combine(
                         creation_time.date(),

--- a/element_array_ephys/readers/kilosort_triggering.py
+++ b/element_array_ephys/readers/kilosort_triggering.py
@@ -98,7 +98,7 @@ class SGLXKilosortPipeline:
 
     def parse_input_filename(self):
         meta_filename = next(self._npx_input_dir.glob("*.ap.meta")).name
-        match = re.search("(.*)_g(\d)_t(\d+|cat)\.imec(\d?)\.ap\.meta", meta_filename)
+        match = re.search(r"(.*)_g(\d)_t(\d+|cat)\.imec(\d?)\.ap\.meta", meta_filename)
         session_str, gate_str, trigger_str, probe_str = match.groups()
         return session_str, gate_str, trigger_str, probe_str or "0"
 
@@ -719,7 +719,7 @@ class OpenEphysKilosortPipeline:
                         ) and previous_line.startswith("Total processing time:"):
                             # regex to search for the processing duration - a float value
                             duration = int(
-                                re.search("\d+\.?\d+", previous_line).group()
+                                re.search(r"\d+\.?\d+", previous_line).group()
                             )
                             return duration
                         previous_line = line

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "plotly",
         "seaborn",
         "spikeinterface",
-        "scikit-image",
+        "scikit-image>=0.20",
         "nbformat>=4.2.0",
         "pyopenephys>=1.1.6",
     ],


### PR DESCRIPTION
This pull request includes two commits. The first commit fixes regex patterns in the code by providing raw annotations for strings with unsupported escape regex sequences. The second commit adds a minimum version requirement for scikit-image in the setup.py file. These changes ensure that the code functions correctly in Python 3.12 and is compatible with the required dependencies.