### PR TITLE
Update: Use `Spikeinterface` official released versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
  [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.4.3] - 2025-06-03
+
++ Update - Use `Spikeinterface` official released versions (instead of install directly from source)
+
 ## [0.4.2] - 2025-03-25
 
 + Fix - Add key_source to `ProbeLevelReport` to filter for 'good' quality units

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "openpyxl",
         "plotly",
         "seaborn",
-        "spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git",
+        "spikeinterface",
         "scikit-image>=0.20",
         "nbformat>=4.2.0",
         "pyopenephys>=1.1.6",


### PR DESCRIPTION
This pull request updates the package to version `0.4.3` and replaces the use of the development version of `Spikeinterface` with its official released versions. Below are the most important changes:

### Version Update:
* Updated the package version from `0.4.2` to `0.4.3` in `element_array_ephys/version.py` to reflect the new release.
* Added a changelog entry for version `0.4.3` in `CHANGELOG.md`, noting the switch to using official `Spikeinterface` releases.

### Dependency Update:
* Modified `setup.py` to replace the `Spikeinterface` dependency from a GitHub source installation (`git+https://github.com/SpikeInterface/spikeinterface.git`) to the official released versions.