### PR TITLE
Moved KiloSort's template_features to _additional_kilosort_files

### DIFF
--- a/element_array_ephys/readers/kilosort.py
+++ b/element_array_ephys/readers/kilosort.py
@@ -21,8 +21,6 @@ class Kilosort:
         "similar_templates.npy",
         "spike_templates.npy",
         "spike_times.npy",
-        "template_features.npy",
-        "template_feature_ind.npy",
         "templates.npy",
         "templates_ind.npy",
         "whitening_mat.npy",
@@ -35,6 +33,8 @@ class Kilosort:
         "spike_times_sec_adj.npy",
         "cluster_groups.csv",
         "cluster_KSLabel.tsv",
+        "template_features.npy",
+        "template_feature_ind.npy",
     ]
 
     kilosort_files = _kilosort_core_files + _kilosort_additional_files

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"


### PR DESCRIPTION
Hello there, 

Our fork of the ephys pipeline current errors out on the ingestion of Kilosort files as part of the element-array-ephys. The error originates specifically in validate , in which certain [required files are part of the ](https://github.com/datajoint/element-array-ephys/blob/0464fe2947e1af4be16004778e9638daf8eee517/element_array_ephys/readers/kilosort.py#L14-L31)_kilosort_core_files (DJ's current repo) but [not part of the Kilosort output](https://github.com/MouseLand/Kilosort/blob/7209ab54dcb29fd8d5f429dd06b48483bf2d48d6/kilosort/io.py#L306-L378) anymore (Kilosort4 repo),  specifically `template_features.npy` and `template_features_ind.npy`

After chatting with @ttngu207, I believe the solution is to move `template_features.npy` and `template_features_ind.npy` from core Kilosort files to the additional files. 

File "/home/u19prod@pu.win.princeton.edu/miniconda3/envs/U19-pipeline_python_env3/lib/python3.12/site-packages/element_array_ephys/readers/kilosort.py", line 78, in validate
   raise FileNotFoundError(
FileNotFoundError: Kilosort files missing in (/mnt/cup/braininit/Data/Processed/electrophysiology/jk8386/jk8386_jk71/20250530_g2/jk71_05302025_g0/jk71_05302025_g0_imec0/job_id_837/kilosort4_output): ['template_features.npy', 'template_feature_ind.npy']