### PR TITLE
version bump to 0.4.6

### DIFF
--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     scripts=[],
     install_requires=[
-        "datajoint>=0.13.0",
+        "datajoint>=0.14.6",
         "ipykernel>=6.0.1",
         "ipywidgets",
         "openpyxl",


### PR DESCRIPTION
This pull request makes a couple of small but important maintenance updates to the package. The version number is incremented and the minimum required version of a key dependency is updated.

- Versioning:
  * Bumped the package version from `0.4.5` to `0.4.6` in `element_array_ephys/version.py`

- Dependency requirements:
  * Updated the minimum required `datajoint` version from `0.13.0` to `0.14.6` in `setup.py`